### PR TITLE
Prettierのインストールと設定をする

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,7 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": [
+    "next",
+    "next/core-web-vitals",
+    "prettier"
+  ]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "autoprefixer": "10.4.0",
         "eslint": "7.32.0",
         "eslint-config-next": "12.0.4",
+        "eslint-config-prettier": "8.3.0",
         "postcss": "8.4.3",
         "prettier": "2.5.0",
         "tailwindcss": "2.2.19",
@@ -2599,6 +2600,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -8522,6 +8535,13 @@
         "eslint-plugin-react": "^7.23.1",
         "eslint-plugin-react-hooks": "^4.2.0"
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint": "7.32.0",
         "eslint-config-next": "12.0.4",
         "postcss": "8.4.3",
+        "prettier": "2.5.0",
         "tailwindcss": "2.2.19",
         "typescript": "4.5.2"
       }
@@ -5093,6 +5094,18 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
+      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/pretty-hrtime": {
@@ -10240,6 +10253,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
+      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
       "dev": true
     },
     "pretty-hrtime": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "autoprefixer": "10.4.0",
     "eslint": "7.32.0",
     "eslint-config-next": "12.0.4",
+    "eslint-config-prettier": "8.3.0",
     "postcss": "8.4.3",
     "prettier": "2.5.0",
     "tailwindcss": "2.2.19",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint": "7.32.0",
     "eslint-config-next": "12.0.4",
     "postcss": "8.4.3",
+    "prettier": "2.5.0",
     "tailwindcss": "2.2.19",
     "typescript": "4.5.2"
   }


### PR DESCRIPTION
# 概要

- PrettierをインストールしてESLintとの競合をせずに動くようにする

# 詳細

- いつの間にか `eslint-plugin-prettier` を使ってESLint上でPrettierのルールを使って解析する方法が非推奨だったので、
`eslint-config-prettier` を使う方法で設定を入れた。

## 今までの `eslint-plugin-prettier` を使う方法

```jsonc
// eslintrc.json
{
  "plugins": ["prettier"],
  "rules": {
    "prettier/prettier": [
      "error",
      {
        "semi": false,
        "singleQuote": true
      }
    ],
}
```

- exlintrc.json に書いてある設定は **Prettierと競合する整形ルールは使わずPrettierのルールをESLintで使う** というもの
- 整形は ESLintが行うので Prettier の拡張機能や `.prettierrc` は不要だった。

```jsonc
// .vscode/settings.json
{
  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
}
```

- VSCodeのデフォルトフォーマッターはESLintを使うよう明示的に指定しておく必要があった。
（Prettierの拡張機能が入ってなければ要らないかも）

## 今回の `eslint-config-prettier` を使う方法

```jsonc
// eslint.json
{
  "extends": ["prettier"]
}
```

```jsonc
// .prettierrc
{
  "semi": false,
  "singleQuote": true
}
```

- exlintrc.json に書いてある設定は **Prettierの方で整形しますんでESLintさんは大人しくしておいてもろて** というもの
- 整形は **Prettier** が行うので Prettier の拡張機能が必要 `.prettierrc` も必要。 eslintrc.json にPrettierのルールを書く必要はなし。

```jsonc
// .vscode/settings.json
{
  "editor.defaultFormatter": "esbenp.prettier-vscode",
}
```

- VSCodeのデフォルトフォーマッターはPrettierを使うよう明示的に指定しておくと吉。
（Prettierの拡張機能が入ってなければ勝手にPrettierが優先されるかも？）

# 参考

- https://knote.dev/post/2020-08-29/duprecated-eslint-plugin-prettier/